### PR TITLE
Specified which class to use in java.util package

### DIFF
--- a/ACM Problems/ArmstrongNumber.java
+++ b/ACM Problems/ArmstrongNumber.java
@@ -1,4 +1,4 @@
-import java.util.*;
+import java.util.Scanner;
 
 public class ArmstrongNumber 
 {


### PR DESCRIPTION
Since you only need the `Scanner` class from `java.util`, it's a good practice that you specify only those that you need.
